### PR TITLE
renamed mfa-code variable

### DIFF
--- a/lib/apigee.js
+++ b/lib/apigee.js
@@ -97,9 +97,9 @@ Apigee.prototype.connect = promiseWrap(function(options, cb) {
       }
       else {
         let arg1 = {password:options.password}; // maybe undefined
-        if (options.mfa_code) { arg1.mfa_code = options.mfa_code; }
+        if (options.mfa_token) { arg1.mfa_token = options.mfa_token; }
         else if (options.passcode) { arg1.passcode = options.passcode; }
-        if ( ! options.password && !options.passcode && !options.mfa_code) {
+        if ( ! options.password && !options.passcode && !options.mfa_token) {
           utility.logWrite('no password, passcode or mfa_code. This probably will not work....');
         }
         return c.getNewToken(arg1, function(e, result){ cb(e, org); });

--- a/lib/apigee.js
+++ b/lib/apigee.js
@@ -100,7 +100,7 @@ Apigee.prototype.connect = promiseWrap(function(options, cb) {
         if (options.mfa_token) { arg1.mfa_token = options.mfa_token; }
         else if (options.passcode) { arg1.passcode = options.passcode; }
         if ( ! options.password && !options.passcode && !options.mfa_token) {
-          utility.logWrite('no password, passcode or mfa_code. This probably will not work....');
+          utility.logWrite('no password, passcode or mfa_token. This probably will not work....');
         }
         return c.getNewToken(arg1, function(e, result){ cb(e, org); });
       }


### PR DESCRIPTION
This pull request solves to an extend the issue mentioned by me here:
https://github.com/DinoChiesa/apigee-edge-js/issues/14

For our usage this solution is sufficient as we provide the mfa token to the library itself as opposed to relying on the library to prompt the user (which is not resolved in this pull request). 

For testing I provided the mfa-token in the testConfig.json before running npm test which allowed connection to mfa enabled account. There appear to be some issues with some testcases but that appears to be a known thing.

regards,
Emile