### PR TITLE
fix: cannot add entry to sealed body object

### DIFF
--- a/lib/kvm.js
+++ b/lib/kvm.js
@@ -167,14 +167,16 @@ Kvm.prototype.create = promiseWrap(function(options, cb) {
   common.insureFreshToken(conn, function(requestOptions) {
     requestOptions.url = resolveKvmPath(conn, options);
     requestOptions.headers['content-type'] = 'application/json';
-    requestOptions.body = JSON.stringify({
+    const body = {
       encrypted : options.encrypted ? "true" : "false",
       name
-    });
+    };
     if (options.entries) {
       // This will not work with GAAMBO
-      requestOptions.body.entry = common.hashToArrayOfKeyValuePairs(options.entries);
+      body.entry = common.hashToArrayOfKeyValuePairs(options.entries);
     }
+    requestOptions.body = JSON.stringify(body);
+
     if (conn.verbosity>0) {
       utility.logWrite(sprintf('POST %s', requestOptions.url));
     }


### PR DESCRIPTION
The result of JSON.stringify ist a sealed and frozen object. NodeJS does not allow adding properties to sealed and frozen objects.  Here's the error message:

```
KVM not updated. Unknown error TypeError: Cannot create property 'entry' on string '{"encrypted":"true","name":"gamp-identity-oidc-secret"}'
    at C:\workspace\apigee-idp-proxy-poc\node_modules\apigee-edge-js\lib\kvm.js:181:35
    at Object.insureFreshToken (C:\workspace\apigee-idp-proxy-poc\node_modules\apigee-edge-js\lib\common.js:124:9)
    at Kvm.<anonymous> (C:\workspace\apigee-idp-proxy-poc\node_modules\apigee-edge-js\lib\kvm.js:168:12)
    at C:\workspace\apigee-idp-proxy-poc\node_modules\apigee-edge-js\lib\promiseWrap.js:37:10
    at new Promise (<anonymous>)
    at Kvm.create (C:\workspace\apigee-idp-proxy-poc\node_modules\apigee-edge-js\lib\promiseWrap.js:19:12)
    at IdpProxyKeyValueMap._create (C:\workspace\apigee-idp-proxy-poc\lib\api\base.js:42:35)
    at async IdpProxyKeyValueMap._updateKeyValueMap (C:\workspace\apigee-idp-proxy-poc\lib\api\idp_proxy_key_values.js:23:13)
    at async IdpProxyKeyValueMap._updateOidcSecretsForOrganization (C:\workspace\apigee-idp-proxy-poc\lib\api\idp_proxy_key_values.js:60:17)
    at async IdpProxyKeyValueMap.update (C:\workspace\apigee-idp-proxy-poc\lib\api\idp_proxy_key_values.js:16:13)
```


The same can be observed on the command line:

```

> console.log('frozen object', Object.isSealed(JSON.stringify({})))
frozen object true
undefined
> const a = JSON.stringify({abc: 'def'})
undefined
> Object.isSealed(a)
true
> Object.isFrozen(a)
true
> a.entry = 'a'
'a'
> a
'{"abc":"def"}'
> a
```
Here the property `entry` was not added to the frozen and sealed object `a`. The cli does not throw an error though.

Changing the order of the commands in `kvm.js` fixes the issue. The new steps are:
1. Create payload object
2. Convert entries if necessary and attach these to the payload object
3. Stringify payload
4. Add payload to request 

Whereas before the change the order was:
1. Create payload object
2. Stringify payload
3. Add payload to request
4. Convert entries if necessary and attach these to the payload object

I'm running node `v4.17.0`

@DinoChiesa would be great if you could release this