### PR TITLE
Fix attributes missing when creating developer apps

### DIFF
--- a/lib/developerApp.js
+++ b/lib/developerApp.js
@@ -78,7 +78,7 @@ DeveloperApp.prototype.create = promiseWrap(function(options, cb) {
     // - array of string (each string a colon-separated pair)
     // - js hash of prop:value pairs
     // - array of hash, each containing key/value pair
-    let attributes1 = common.maybeReformAttributes(options.attributes | {}),
+    let attributes1 = common.maybeReformAttributes(options.attributes || {}),
         tool = 'nodejs ' + path.basename(process.argv[1]),
         appAttributes = common.hashToArrayOfKeyValuePairs({ ...attributes1, tool }),
         apiProducts = (Array.isArray(product)) ? product : [product];


### PR DESCRIPTION
Attributes are missing when creating developer app.

Root cause:
`|`Bitwise OR operator is being used instead of Logical OR.
```js
common.maybeReformAttributes(options.attributes | {})
```

Sulotion:
Use `||` Logical OR instead.
```js
common.maybeReformAttributes(options.attributes || {})
```