### PR TITLE
fix: missing pipe symbol cause actual bit comparison

### DIFF
--- a/lib/developerApp.js
+++ b/lib/developerApp.js
@@ -83,7 +83,7 @@ DeveloperApp.prototype.create = promiseWrap(function (options, cb) {
     // - array of string (each string a colon-separated pair)
     // - js hash of prop:value pairs
     // - array of hash, each containing key/value pair
-    let attributes1 = common.maybeReformAttributes(options.attributes | {}),
+    let attributes1 = common.maybeReformAttributes(options.attributes || {}),
       tool = "nodejs " + path.basename(process.argv[1]),
       appAttributes = common.hashToArrayOfKeyValuePairs({
         ...attributes1,


### PR DESCRIPTION
hi @DinoChiesa 

just a minor issue here, which caused attributes to be reset during creation of a new developer app.

Would be great if you could publish a new release 😊